### PR TITLE
Add `String` to std_msgs.py

### DIFF
--- a/zenoh_ros_type/common_interfaces/std_msgs.py
+++ b/zenoh_ros_type/common_interfaces/std_msgs.py
@@ -14,3 +14,7 @@ class ColorRGBA(IdlStruct, typename="ColorRGBA"):
     g: float32
     b: float32
     a: float32
+
+@dataclass
+class String(IdlStruct, typename="String"):
+    data: str


### PR DESCRIPTION
Hey I noticed the std_msgs `String` message was missing so I added it.